### PR TITLE
Add selection by parentId feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ materials/
 /ref
 /ticktock
 *.ai
+.idea

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var Chronograph = require('./dist/modules/Chronograph');
 var Foudroyante = require('./dist/modules/Foudroyante');
 
 var Watch = function () {
-  function Watch(settings) {
+  function Watch(settings, parentId) {
     var _this = this;
 
     _classCallCheck(this, Watch);
@@ -47,7 +47,7 @@ var Watch = function () {
     this.rightNow = Moment();
 
     settings.dials.forEach(function (dial) {
-      var tempDial = new Dial(dial, _this);
+      var tempDial = new Dial(dial, _this, parentId);
       _this.dialInstances.push(tempDial);
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ const Chronograph = require('./modules/Chronograph');
 const Foudroyante = require('./modules/Foudroyante');
 
 class Watch {
-  constructor(settings) {
+  constructor(settings, parentId) {
     if (settings.testing) return;
 
     try {
@@ -38,7 +38,7 @@ class Watch {
     this.rightNow = Moment();
 
     settings.dials.forEach((dial) => {
-      let tempDial = new Dial(dial, this);
+      let tempDial = new Dial(dial, this, parentId);
       this.dialInstances.push(tempDial);
     });
 


### PR DESCRIPTION
Adds a parent id selection feature.

It behaves has following:
- If no id is specified in the setting for an element and a parent id is specified then it will try to find an HTML element inside the given parent id with a default class name like "hands-second", "hands-minute", "retrograde-second", etc.
- If an id is specified in the setting for an element and a parent id is specified then it will try to find an HTML element inside the given parent id with a class name that matches the setting id. If no element is found it will then try to find the element inside the given parent id with an HTML id that matches the given setting id. If the previous fails, then it will log a warning and it will try to find the element by id in the whole document.
- If no parent id is specified it will try to find the element by the specified id in the settings.

Closes #9 